### PR TITLE
Add formatting of `Cargo.toml` files as per convention

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,10 @@ tracing = ["dprint-core/tracing"]
 
 [dependencies]
 dprint-core = { version = "0.43.0", features = ["formatting"] }
-taplo = { version = "0.6.1", default_features = false }
+taplo = { git = "https://github.com/thomaseizinger/taplo", rev = "68d8e32", default_features = false }
 serde = { version = "1.0.88", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
+itertools = "0.10"
 
 [dev-dependencies]
 dprint-development = "0.4.1"

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -1,0 +1,116 @@
+use std::cmp::Ordering;
+use std::iter::Peekable;
+use std::path::Path;
+use taplo::rowan::SyntaxElement;
+use taplo::syntax::{SyntaxKind, SyntaxNode};
+
+pub fn is_cargo_toml_file(file_path: &Path) -> bool {
+    // don't need to worry about different casing because Cargo.toml will
+    // always have this same casing https://github.com/rust-lang/cargo/issues/45
+    file_path
+        .file_name()
+        .map(|n| n == "Cargo.toml")
+        .unwrap_or(false)
+}
+
+pub fn apply_cargo_toml_conventions(node: SyntaxNode) -> SyntaxNode {
+    let node = node.clone_for_update(); // use mutable API to make updates easier
+    let mut children = node.children().peekable();
+
+    while let Some(child) = children.next() {
+        if child.text() == "[package]" {
+            let mut package_section = Section::new(&child, &mut children);
+            package_section.apply_formatting_conventions(sort_cargo_package_section);
+            package_section.insert(&node);
+        }
+        if child.text() == "[dependencies]" || child.text() == "[dev-dependencies]" {
+            let mut package_section = Section::new(&child, &mut children);
+            package_section.apply_formatting_conventions(|left, right| {
+                left.entry_key_text().cmp(&right.entry_key_text())
+            });
+            package_section.insert(&node);
+        }
+    }
+
+    node
+}
+
+fn sort_cargo_package_section(left: &SyntaxNode, right: &SyntaxNode) -> Ordering {
+    match (
+        left.entry_key_text().as_str(),
+        right.entry_key_text().as_str(),
+    ) {
+        ("name", _) => Ordering::Less,
+        ("version", "name") => Ordering::Greater,
+        ("version", _) => Ordering::Less,
+        ("description", _) => Ordering::Greater,
+        (_, "name") => Ordering::Greater,
+        (_, "version") => Ordering::Greater,
+
+        (left, right) => left.cmp(right),
+    }
+}
+
+#[derive(Debug)]
+struct Section {
+    nodes: Vec<SyntaxNode>,
+    table_header_index: usize,
+}
+
+impl Section {
+    fn new(
+        table_header: &SyntaxNode,
+        tree: &mut Peekable<impl Iterator<Item = SyntaxNode>>,
+    ) -> Self {
+        let mut nodes = vec![];
+
+        while let Some(entry) = tree.next_if(|child| child.kind() == SyntaxKind::ENTRY) {
+            nodes.push(entry);
+        }
+
+        Self {
+            nodes,
+            table_header_index: table_header.index(),
+        }
+    }
+
+    fn apply_formatting_conventions(
+        &mut self,
+        cmp: impl FnMut(&SyntaxNode, &SyntaxNode) -> Ordering,
+    ) {
+        self.nodes.sort_by(cmp);
+    }
+
+    fn insert(self, node: &SyntaxNode) {
+        let start = self.table_header_index + 1;
+        let end = start + self.nodes.len();
+
+        node.splice_children(
+            start..end,
+            self.nodes.into_iter().map(SyntaxElement::Node).collect(),
+        )
+    }
+}
+
+trait SyntaxNodeExt {
+    fn entry_key_text(&self) -> String;
+}
+
+impl SyntaxNodeExt for SyntaxNode {
+    fn entry_key_text(&self) -> String {
+        let key = self
+            .children()
+            .find(|child| child.kind() == SyntaxKind::KEY)
+            .expect("ENTRY should contain KEY");
+
+        let ident = key
+            .children_with_tokens()
+            .find_map(|child| match child {
+                SyntaxElement::Token(token) if token.kind() == SyntaxKind::IDENT => Some(token),
+                _ => None,
+            })
+            .expect("KEY should contain IDENT");
+
+        ident.to_string()
+    }
+}

--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -3,9 +3,14 @@ use super::parser::parse_items;
 use dprint_core::configuration::resolve_new_line_kind;
 use dprint_core::formatting::PrintOptions;
 use dprint_core::types::ErrBox;
+use std::path::Path;
 use taplo::syntax::SyntaxNode;
 
-pub fn format_text(text: &str, config: &Configuration) -> Result<String, ErrBox> {
+pub fn format_text(
+    _file_path: &Path,
+    text: &str,
+    config: &Configuration,
+) -> Result<String, ErrBox> {
     let node = parse_taplo(text)?;
 
     Ok(dprint_core::formatting::format(

--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -1,17 +1,14 @@
 use super::configuration::Configuration;
 use super::parser::parse_items;
+use crate::cargo;
 use dprint_core::configuration::resolve_new_line_kind;
 use dprint_core::formatting::PrintOptions;
 use dprint_core::types::ErrBox;
 use std::path::Path;
 use taplo::syntax::SyntaxNode;
 
-pub fn format_text(
-    _file_path: &Path,
-    text: &str,
-    config: &Configuration,
-) -> Result<String, ErrBox> {
-    let node = parse_taplo(text)?;
+pub fn format_text(file_path: &Path, text: &str, config: &Configuration) -> Result<String, ErrBox> {
+    let node = parse_and_process_node(file_path, text)?;
 
     Ok(dprint_core::formatting::format(
         || parse_items(node, text, config),
@@ -20,13 +17,27 @@ pub fn format_text(
 }
 
 #[cfg(feature = "tracing")]
-pub fn trace_file(text: &str, config: &Configuration) -> dprint_core::formatting::TracingResult {
-    let node = parse_taplo(text).unwrap();
+pub fn trace_file(
+    file_path: &Path,
+    text: &str,
+    config: &Configuration,
+) -> dprint_core::formatting::TracingResult {
+    let node = parse_and_process_node(file_path, text).unwrap();
 
     dprint_core::formatting::trace_printing(
         || parse_items(node, text, config),
         config_to_print_options(text, config),
     )
+}
+
+fn parse_and_process_node(file_path: &Path, text: &str) -> Result<SyntaxNode, String> {
+    let node = parse_taplo(text)?;
+
+    Ok(if cargo::is_cargo_toml_file(file_path) {
+        cargo::apply_cargo_toml_conventions(node)
+    } else {
+        node
+    })
 }
 
 fn parse_taplo(text: &str) -> Result<SyntaxNode, String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod cargo;
 pub mod configuration;
 mod format_text;
 mod parser;

--- a/src/wasm_plugin.rs
+++ b/src/wasm_plugin.rs
@@ -42,12 +42,12 @@ impl PluginHandler<Configuration> for TomlPluginHandler {
 
     fn format_text(
         &mut self,
-        _file_path: &Path,
+        file_path: &Path,
         file_text: &str,
         config: &Configuration,
         _format_with_host: impl FnMut(&Path, String, &ConfigKeyMap) -> Result<String, ErrBox>,
     ) -> Result<String, ErrBox> {
-        super::format_text(file_text, config)
+        super::format_text(file_path, file_text, config)
     }
 }
 

--- a/tests/specs/CargoToml/CargoToml_All.txt
+++ b/tests/specs/CargoToml/CargoToml_All.txt
@@ -1,0 +1,108 @@
+-- Cargo.toml --
+== should format "comit" Cargo.toml file ==
+[package]
+authors = ["CoBloX <hello@coblox.tech>"]
+name = "comit"
+version = "0.1.0"
+edition = "2018"
+description = "Core components of the COMIT protocol"
+
+[dependencies]
+libp2p = { version = "0.29", default-features = false, features = ["gossipsub", "request-response"] }
+async-trait = "0.1"
+base64 = "0.13"
+bitcoin = { version = "0.25", features = ["rand", "use-serde"] }
+serde_derive = "1.0"
+byteorder = "1.3"
+conquer-once = "0.2"
+serde_json = "1"
+anyhow = "1"
+ethbloom = "0.9"
+testcontainers = { version = "0.10", optional = true } # In dependencies instead of dev-dependencies so it can be set as optional, only used for test purposes
+futures = { version = "0.3", default-features = false }
+genawaiter = { version = "0.99", default-features = false, features = ["futures03"] }
+hex = { version = "0.4", features = ["serde"] }
+levenshtein = "1"
+tracing-futures = { version = "0.2" }
+lru = "0.6"
+num = "0.3"
+quickcheck = { version = "0.9", optional = true }
+rand = "0.7"
+reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls-vendored"] }
+serde = { version = "1", features = ["derive"] }
+derivative = "2"
+serdebug = "1"
+blockchain_contracts = "0.4"
+strum = "0.19"
+primitive-types = { version = "0.7", features = ["serde"] }
+strum_macros = "0.19"
+thiserror = "1"
+time = { version = "0.2", features = ["serde"] }
+tokio = { version = "0.2", features = ["sync"] }
+tracing = "0.1.21"
+uuid = { version = "0.8", features = ["serde", "v4"] }
+
+[dev-dependencies]
+bitcoincore-rpc = "0.12"
+libp2p = { version = "0.29", default-features = false, features = ["yamux", "noise"] }
+proptest = "0.10"
+spectral = { version = "0.6", default-features = false }
+tokio = { version = "0.2", features = ["macros"] }
+
+[features]
+default = []
+test = ["libp2p/yamux", "libp2p/noise"]
+
+[expect]
+[package]
+name = "comit"
+version = "0.1.0"
+authors = ["CoBloX <hello@coblox.tech>"]
+edition = "2018"
+description = "Core components of the COMIT protocol"
+
+[dependencies]
+anyhow = "1"
+async-trait = "0.1"
+base64 = "0.13"
+bitcoin = { version = "0.25", features = ["rand", "use-serde"] }
+blockchain_contracts = "0.4"
+byteorder = "1.3"
+conquer-once = "0.2"
+derivative = "2"
+ethbloom = "0.9"
+futures = { version = "0.3", default-features = false }
+genawaiter = { version = "0.99", default-features = false, features = ["futures03"] }
+hex = { version = "0.4", features = ["serde"] }
+levenshtein = "1"
+libp2p = { version = "0.29", default-features = false, features = ["gossipsub", "request-response"] }
+lru = "0.6"
+num = "0.3"
+primitive-types = { version = "0.7", features = ["serde"] }
+quickcheck = { version = "0.9", optional = true }
+rand = "0.7"
+reqwest = { version = "0.10", default-features = false, features = ["json", "native-tls-vendored"] }
+serde = { version = "1", features = ["derive"] }
+serde_derive = "1.0"
+serde_json = "1"
+serdebug = "1"
+strum = "0.19"
+strum_macros = "0.19"
+testcontainers = { version = "0.10", optional = true } # In dependencies instead of dev-dependencies so it can be set as optional, only used for test purposes
+thiserror = "1"
+time = { version = "0.2", features = ["serde"] }
+tokio = { version = "0.2", features = ["sync"] }
+tracing = "0.1.21"
+tracing-futures = { version = "0.2" }
+uuid = { version = "0.8", features = ["serde", "v4"] }
+
+[dev-dependencies]
+bitcoincore-rpc = "0.12"
+libp2p = { version = "0.29", default-features = false, features = ["yamux", "noise"] }
+proptest = "0.10"
+spectral = { version = "0.6", default-features = false }
+tokio = { version = "0.2", features = ["macros"] }
+
+[features]
+default = []
+test = ["libp2p/yamux", "libp2p/noise"]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -28,12 +28,12 @@ fn test_specs() {
         },
         {
             let global_config = global_config.clone();
-            move |_, file_text, spec_config| {
+            move |file_path, file_text, spec_config| {
                 let config_result =
                     resolve_config(parse_config_key_map(spec_config), &global_config);
                 ensure_no_diagnostics(&config_result.diagnostics);
 
-                format_text(&file_text, &config_result.config)
+                format_text(file_path, &file_text, &config_result.config)
             }
         },
         move |_, _file_text, _spec_config| {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -36,14 +36,18 @@ fn test_specs() {
                 format_text(file_path, &file_text, &config_result.config)
             }
         },
-        move |_, _file_text, _spec_config| {
+        move |_file_path, _file_text, _spec_config| {
             #[cfg(feature = "tracing")]
             {
                 let config_result =
                     resolve_config(parse_config_key_map(_spec_config), &global_config);
                 ensure_no_diagnostics(&config_result.diagnostics);
-                return serde_json::to_string(&trace_file(_file_text, &config_result.config))
-                    .unwrap();
+                return serde_json::to_string(&trace_file(
+                    _file_path,
+                    _file_text,
+                    &config_result.config,
+                ))
+                .unwrap();
             }
 
             #[cfg(not(feature = "tracing"))]


### PR DESCRIPTION
Draft PR to showcase what I currently have.

Will eventually resolve https://github.com/thomaseizinger/dprint-plugin-cargo-toml/issues/1.

A few notes:

1. I opted to add the rustfmt plugin to this repo. Let me know if you don't want that as part of this PR.
2. I had to fork `taplo` to bump `rowan` to the latest pre-release. This is necessary to get access to the new "mutation" API of rowan which makes life a lot easier for mutating the syntax tree.
3. The formatting works for basic usecases. The testcase currently only fails because the trialing comment gets eaten somehow. If you have a spare minute, do mind having a look at that @dsherret?