### PR TITLE
fix: handle doc-like comments when forcing a leading space

### DIFF
--- a/tests/specs/Comments/Comments_ForceLeadingSpace_False.txt
+++ b/tests/specs/Comments/Comments_ForceLeadingSpace_False.txt
@@ -20,3 +20,13 @@
 
 [expect]
 #	test
+
+== should not force when is #! ==
+#! Test
+#!Test
+#!## Test
+
+[expect]
+#! Test
+#!Test
+#!## Test

--- a/tests/specs/Comments/Comments_ForceLeadingSpace_True.txt
+++ b/tests/specs/Comments/Comments_ForceLeadingSpace_True.txt
@@ -16,3 +16,13 @@
 #  test
 #   test
 #    test
+
+== should force when is #! ==
+#! Test
+#!Test
+#!## Test
+
+[expect]
+#! Test
+#! Test
+#! ## Test


### PR DESCRIPTION
Closes https://github.com/dprint/dprint-plugin-toml/issues/23